### PR TITLE
chore: pull jest up in the test pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "lint": "eslint --ext=.ts --fix src/",
     "format": "prettier --loglevel error --write \"./**/*.ts\"",
-    "test": "tsc && prettier --check \"./**/*.ts\" && eslint --ext=.ts src/ && jest"
+    "test": "tsc && jest && prettier --check \"./**/*.ts\" && eslint --ext=.ts src/"
   },
   "prettier": "@valora/prettier-config",
   "devDependencies": {


### PR DESCRIPTION
It's annoying to try and run unit tests with `yarn test`, and for the linters to prevent it.